### PR TITLE
Add integration env vars

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,8 @@ deployment:
     - '-c'
     - 'while ! curl http://eazy-kotlin-test-service:7070/health; do sleep 1; done;'
 integration:
+  env:
+    - 'FOO=bar'
   bootstrap:
     - '/bin/sh'
     - '-c'

--- a/lib/config/eazy_yml.go
+++ b/lib/config/eazy_yml.go
@@ -22,6 +22,7 @@ type EazyYml struct {
 		Health []string
 	}
 	Integration struct {
+		Env              []string
 		Bootstrap        []string
 		RunTest          []string `yaml:"runTest"`
 		Dependencies     []string

--- a/lib/config/eazy_yml_test.go
+++ b/lib/config/eazy_yml_test.go
@@ -40,7 +40,8 @@ func TestEazyYml(t *testing.T) {
 		eazy.Build.Image != "gradle:5.6.2-jdk8" ||
 		eazy.Build.Command[2] != "gradle build" ||
 		eazy.Deployment.Env[0] != "APP_ENV=integration" ||
-		eazy.Build.BuildEnvironment != "gradle" {
+		eazy.Build.BuildEnvironment != "gradle" ||
+		eazy.Integration.Env[0] != "FOO=bar" {
 		t.Error(eazy)
 	}
 

--- a/lib/config/testdata/test-eazy.yml
+++ b/lib/config/testdata/test-eazy.yml
@@ -20,6 +20,8 @@ deployment:
     - '-c'
     - 'while ! curl http://host.docker.internal:8080/health; do sleep 1; done;'
 integration:
+  env:
+    - 'FOO=bar'
   bootstrap:
     - '/bin/sh'
     - '-c'

--- a/main.go
+++ b/main.go
@@ -127,12 +127,15 @@ func main() {
 		}
 	}
 
+	// Get integration env variables
+	integrationEnv := yml.Integration.Env
+
 	for _, d := range peerDependencies {
-		startUnit(ctx, d, *openPortsLocally, runtime)
+		startUnit(ctx, d, *openPortsLocally, runtime, integrationEnv)
 	}
 
 	for _, d := range dependencies {
-		startUnit(ctx, d, *openPortsLocally, runtime)
+		startUnit(ctx, d, *openPortsLocally, runtime, integrationEnv)
 	}
 
 	envBuilder := builders.GetBuildEnvironment(yml.Build.BuildEnvironment)
@@ -262,7 +265,7 @@ func main() {
 	doCleanup(nil)
 }
 
-func startUnit(ctx context.Context, yml config.EazyYml, openPortsLocally bool, runtime runtimes.ContainerRuntime) {
+func startUnit(ctx context.Context, yml config.EazyYml, openPortsLocally bool, runtime runtimes.ContainerRuntime, additionalEnv []string) {
 	doCleanup := cleanUp(ctx, &runtime)
 
 	if len(yml.Integration.Bootstrap) > 0 {
@@ -277,7 +280,7 @@ func startUnit(ctx context.Context, yml config.EazyYml, openPortsLocally bool, r
 		}
 	}
 	_, err := runtime.StartContainerByEazyYml(ctx, yml, "", config.RuntimeConfig{
-		Env:         yml.Deployment.Env,
+		Env:         append(yml.Deployment.Env, additionalEnv...),
 		Wait:        false,
 		ExposePorts: openPortsLocally,
 		IsRootImage: true,


### PR DESCRIPTION
Adding the ability to specify extra env vars for dependencies and peer dependencies. This is useful because I want to specify env vars on top of those defined in a dependency's eazy specification.